### PR TITLE
Settings

### DIFF
--- a/cse3902/Collision/Collidables/EnemyCollidable.cs
+++ b/cse3902/Collision/Collidables/EnemyCollidable.cs
@@ -5,6 +5,7 @@ using cse3902.Projectiles;
 using cse3902.Rooms;
 using cse3902.Entities.Enemies;
 using Microsoft.Xna.Framework;
+using cse3902.Constants;
 
 namespace cse3902.Collision.Collidables
 {
@@ -44,7 +45,6 @@ namespace cse3902.Collision.Collidables
             } else if (collidableObject is DoorCollidable || collidableObject is WallCollidable)
             {
                 DoorWallCollision(collidableObject);
-
 
             } else if (collidableObject is BlockCollidable)
             {
@@ -129,12 +129,16 @@ namespace cse3902.Collision.Collidables
             {
                 return;
             }
-
             if (this.enemy is Dodongo && !(((ProjectileCollidable)collidableObject).Projectile is BombProjectile))
             {
                 return;
             }
- 
+            if (!(this.enemy is Aquamentus || this.enemy is BoggusBoss || this.enemy is MarioBoss || this.enemy is Dodongo)) {
+                if (((ProjectileCollidable)collidableObject).Projectile is BoomerangProjectile)
+                {
+                    if (this.enemy.Stunned.StunDuration < DamageConstants.BoomerangStunDuration) this.enemy.Stunned = (true, DamageConstants.BoomerangStunDuration);
+                }
+            }
 
             this.enemy.TakeDamage(collidableObject.DamageValue);
             if (this.enemy.Health <= 0)

--- a/cse3902/Collision/Collidables/PlayerCollidable.cs
+++ b/cse3902/Collision/Collidables/PlayerCollidable.cs
@@ -80,7 +80,8 @@ namespace cse3902.Collision.Collidables
         }
 
         private void EnemyCollision(ICollidable collidableObject)
-        {           
+        {
+            if (((EnemyCollidable)collidableObject).Enemy.Stunned.Stun) return;
             if (((EnemyCollidable)collidableObject).Enemy is WallMaster)
             {
                 if (((WallMaster)((EnemyCollidable)collidableObject).Enemy).IsTriggered)

--- a/cse3902/Collision/Collidables/ProjectileCollidable.cs
+++ b/cse3902/Collision/Collidables/ProjectileCollidable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using cse3902.Interfaces;
-using System.Collections.Generic;
 using cse3902.Rooms;
 using cse3902.Projectiles;
 using Microsoft.Xna.Framework;
@@ -11,37 +10,56 @@ namespace cse3902.Collision.Collidables
     {
         private IProjectile projectile;
         private Boolean collisionOccurrence;
+        private Game1 game;
 
         public bool DamageDisabled { get; set; }
         
-	    public ProjectileCollidable(IProjectile projectile)
+	    public ProjectileCollidable(IProjectile projectile, Game1 game)
         {
             this.projectile = projectile;
             DamageDisabled = true;
             collisionOccurrence = false;
+            this.game = game;
         }
 
 
         public void OnCollidedWith(ICollidable collidableObject)
         {
-            if (collidableObject is DoorCollidable || collidableObject is WallCollidable || collidableObject is EnemyCollidable)
+            if (this.projectile is BoomerangProjectile) BoomerangCollision(collidableObject);
+            else if (this.projectile is EnemyBoomerangProjectile)
             {
-                if (collisionOccurrence)
-                {
-                    return;
-                }
-                collisionOccurrence = true;
-                RoomProjectiles.Instance.RemoveProjectile(this.projectile);
+                if (collidableObject is DoorCollidable || collidableObject is WallCollidable || collidableObject is PlayerCollidable) ((EnemyBoomerangProjectile)projectile).ReverseDirectionIfNecessary();
             }
-
-            if (collidableObject is PlayerCollidable && this.IsEnemy)
+            else
             {
-                if (collisionOccurrence)
+                if (collidableObject is DoorCollidable || collidableObject is WallCollidable || (collidableObject is EnemyCollidable && !this.IsEnemy))
                 {
-                    return;
+                    if (collisionOccurrence)
+                    {
+                        return;
+                    }
+                    collisionOccurrence = true;
+                    RoomProjectiles.Instance.RemoveProjectile(this.projectile);
                 }
-                collisionOccurrence = true;
-                RoomProjectiles.Instance.RemoveProjectile(this.projectile);
+
+                if (collidableObject is PlayerCollidable && this.IsEnemy)
+                {
+                    if (collisionOccurrence)
+                    {
+                        return;
+                    }
+                    collisionOccurrence = true;
+                    RoomProjectiles.Instance.RemoveProjectile(this.projectile);
+                }
+            }
+        }
+
+        private void BoomerangCollision(ICollidable collidableObject)
+        {
+            if (collidableObject is ItemCollidable) game.Player.AddItem(((ItemCollidable)collidableObject).Item);
+            else if (collidableObject is DoorCollidable || collidableObject is WallCollidable || collidableObject is EnemyCollidable)
+            {
+                ((BoomerangProjectile)projectile).ReverseDirectionIfNecessary();
             }
         }
 
@@ -52,16 +70,7 @@ namespace cse3902.Collision.Collidables
 
         public Boolean IsEnemy
         {
-            get
-            {
-                if (this.projectile is Fireball)
-                {
-                    return true;
-                } else
-                {
-                    return false;
-                }
-            }
+            get => this.projectile is Fireball || this.projectile is EnemyBoomerangProjectile;
         }
 
         public int DamageValue

--- a/cse3902/Constants/DamageConstants.cs
+++ b/cse3902/Constants/DamageConstants.cs
@@ -16,6 +16,9 @@ namespace cse3902.Constants
         public const int WhiteSwordDamage = 2 * WoodSwordDamage;
         public const int MagicalSwordDamage = 2 * WhiteSwordDamage;
 
+        public const float BoomerangStunDuration = 2.5f;
+        public const float ClockStunDuration = 9999;
+
         public static int SwordDamage
         {
             get

--- a/cse3902/Constants/ItemConstants.cs
+++ b/cse3902/Constants/ItemConstants.cs
@@ -43,6 +43,7 @@ namespace cse3902.Constants
         public const float BombDelay = 0.8f;
 
         public const int BoomerangTravelDistance = (int) (5 * RoomUtilities.BLOCK_SIDE / BoomerangSpeed);
+        public const int EnemyBoomerangTravelDistance = (int)(6 * RoomUtilities.BLOCK_SIDE / BoomerangSpeed);
         public const float BoomerangSpeed = 2f;
 
         public const float FireballSpeed = 1.3f;

--- a/cse3902/Constants/ItemConstants.cs
+++ b/cse3902/Constants/ItemConstants.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using cse3902.Rooms;
 
 namespace cse3902.Constants
 {
@@ -41,8 +42,8 @@ namespace cse3902.Constants
         public const int BombCols = 1;
         public const float BombDelay = 0.8f;
 
-        public const int BoomerangTravelDistance = 35;
-        public const float BoomerangSpeed = 1.25f;
+        public const int BoomerangTravelDistance = (int) (5 * RoomUtilities.BLOCK_SIDE / BoomerangSpeed);
+        public const float BoomerangSpeed = 2f;
 
         public const float FireballSpeed = 1.3f;
         public const float MagicFireballSpeed = 1.5f;

--- a/cse3902/Entities/Enemies/Aquamentus.cs
+++ b/cse3902/Entities/Enemies/Aquamentus.cs
@@ -202,5 +202,11 @@ namespace cse3902.Entities.Enemies
         {
             get => this.collidable;
         }
+
+        public (bool,float) Stunned
+        {
+            get => (false, 0);
+            set { }
+        }
     }
 }

--- a/cse3902/Entities/Enemies/BoggusBoss.cs
+++ b/cse3902/Entities/Enemies/BoggusBoss.cs
@@ -202,5 +202,11 @@ namespace cse3902.Entities.Enemies
         {
             get => this.collidable;
         }
+
+        public (bool, float) Stunned
+        {
+            get => (false, 0);
+            set { }
+        }
     }
 }

--- a/cse3902/Entities/Enemies/Dodongo.cs
+++ b/cse3902/Entities/Enemies/Dodongo.cs
@@ -276,5 +276,11 @@ namespace cse3902.Entities.Enemies
         {
             get => this.collidable;
         }
+
+        public (bool, float) Stunned
+        {
+            get => (false, 0);
+            set {}
+        }
     }
 }

--- a/cse3902/Entities/Enemies/Gel.cs
+++ b/cse3902/Entities/Enemies/Gel.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework;
 using cse3902.Constants;
 using cse3902.Sounds;
 using cse3902.ParticleSystem;
+using cse3902.Rooms;
 
 namespace cse3902.Entities.Enemies
 {
@@ -224,6 +225,15 @@ namespace cse3902.Entities.Enemies
         public ICollidable Collidable
         {
             get => this.collidable;
+        }
+
+        public (bool Stun, float StunDuration) Stunned
+        {
+            get => (false, 0);
+            set
+            {
+                if (value.Stun) health = 0;
+            }
         }
     }
 }

--- a/cse3902/Entities/Enemies/Keese.cs
+++ b/cse3902/Entities/Enemies/Keese.cs
@@ -8,6 +8,7 @@ using System;
 using cse3902.Constants;
 using cse3902.Sounds;
 using cse3902.ParticleSystem;
+using cse3902.Rooms;
 
 namespace cse3902.Entities.Enemies
 {
@@ -235,6 +236,15 @@ namespace cse3902.Entities.Enemies
         public ICollidable Collidable
         {
             get => this.collidable;
+        }
+
+        public (bool Stun, float StunDuration) Stunned
+        {
+            get => (false, 0);
+            set
+            {
+                if (value.Stun) health = 0;
+            }
         }
     }
 }

--- a/cse3902/Entities/Enemies/MarioBoss.cs
+++ b/cse3902/Entities/Enemies/MarioBoss.cs
@@ -204,5 +204,11 @@ namespace cse3902.Entities.Enemies
         {
             get => this.collidable;
         }
+
+        public (bool,float) Stunned
+        {
+            get => (false, 0);
+            set { }
+        }
     }
 }

--- a/cse3902/Entities/Enemies/Stalfos.cs
+++ b/cse3902/Entities/Enemies/Stalfos.cs
@@ -18,8 +18,7 @@ namespace cse3902.Entities.Enemies
 
         private Vector2 direction;
         private float speed;
-        private Vector2 center;
-        private Vector2 previousCenter;
+        private (Vector2 previous, Vector2 current) center;
         private int travelDistance;
         private Vector2 shoveDirection;
         private int shoveDistance;
@@ -28,14 +27,16 @@ namespace cse3902.Entities.Enemies
         private int health;
         private float remainingDamageDelay;
 
+        private (bool stun, float stunDuration) stun;
+
         public Stalfos(Game1 game, Vector2 start)
         {
             this.game = game;
-            center = start;
-            previousCenter = center;
+            center.current = start;
+            center.previous = start;
 
             //stalfos sprite sheet is 1 row, 2 columns
-            stalfosSprite = (StalfosSprite)EnemySpriteFactory.Instance.CreateStalfosSprite(game.SpriteBatch, center);
+            stalfosSprite = (StalfosSprite)EnemySpriteFactory.Instance.CreateStalfosSprite(game.SpriteBatch, center.current);
             speed = MovementConstants.StalfosSpeed;
             travelDistance = 0;
             shoveDistance = MovementConstants.DefaultShoveDistance;
@@ -43,6 +44,8 @@ namespace cse3902.Entities.Enemies
 
             this.collidable = new EnemyCollidable(this, this.Damage);
             health = SettingsValues.Instance.GetValue(SettingsValues.Variable.StalfosHealth);
+
+            stun = (false, 0);
         }
 
         public ref Rectangle Bounds
@@ -80,8 +83,8 @@ namespace cse3902.Entities.Enemies
         public void Die()
         {
             SoundFactory.PlaySound(SoundFactory.Instance.enemyDie);
-            ItemSpriteFactory.Instance.SpawnRandomItem(game.SpriteBatch, center, IEntity.EnemyType.C);
-            if (ParticleEngine.Instance.UseParticleEffects) ParticleEngine.Instance.CreateEnemyDeathEffect(center);
+            ItemSpriteFactory.Instance.SpawnRandomItem(game.SpriteBatch, center.current, IEntity.EnemyType.C);
+            if (ParticleEngine.Instance.UseParticleEffects) ParticleEngine.Instance.CreateEnemyDeathEffect(center.current);
         }
 
         public void BeShoved()
@@ -110,8 +113,15 @@ namespace cse3902.Entities.Enemies
             }
         }
 
+        private void UpdateStun(GameTime gameTime)
+        {
+            stun.stunDuration -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+            stun.stun = stun.stunDuration > 0;
+        }
+
         public void Update(GameTime gameTime)
         {
+            UpdateStun(gameTime);
             UpdateDamage(gameTime);
 	        this.collidable.ResetCollisions();
             if (this.shoveDistance > 0) ShoveMovement();
@@ -131,18 +141,20 @@ namespace cse3902.Entities.Enemies
 
         private void RegularMovement(GameTime gameTime)
         {
-            this.Center += direction * speed * (float)gameTime.ElapsedGameTime.TotalSeconds;
-
-            if (travelDistance <= 0)
+            if (!stun.stun)
             {
-                travelDistance = MovementConstants.StalfosMaxTravel;
-                RandomDirection();
-            }
-            else
-            {
-                travelDistance--;
-            }
+                this.Center += direction * speed * (float)gameTime.ElapsedGameTime.TotalSeconds;
 
+                if (travelDistance <= 0)
+                {
+                    travelDistance = MovementConstants.StalfosMaxTravel;
+                    RandomDirection();
+                }
+                else
+                {
+                    travelDistance--;
+                }
+            }
             stalfosSprite.Update(gameTime);
         }
 
@@ -172,7 +184,7 @@ namespace cse3902.Entities.Enemies
 
         public IEntity Duplicate()
         {
-            return new Stalfos(game, center);
+            return new Stalfos(game, center.current);
         }
 
         public IEntity.EnemyType Type
@@ -182,21 +194,21 @@ namespace cse3902.Entities.Enemies
 
         public Vector2 Center
         {
-            get => this.center;
+            get => this.center.current;
             set
             {
-                this.PreviousCenter = this.center;
-                this.center = value;
+                this.PreviousCenter = this.center.current;
+                this.center.current = value;
                 stalfosSprite.Center = value;
             }
         }
 
         public Vector2 PreviousCenter
         {
-            get => this.previousCenter;
+            get => this.center.previous;
             set
             {
-                this.previousCenter = value;
+                this.center.previous = value;
             }
         }
 
@@ -222,6 +234,12 @@ namespace cse3902.Entities.Enemies
         public ICollidable Collidable
         {
             get => this.collidable;
+        }
+
+        public (bool, float) Stunned
+        {
+            get => stun;
+            set => stun = value;
         }
     }
 }

--- a/cse3902/Entities/Enemies/WallMaster.cs
+++ b/cse3902/Entities/Enemies/WallMaster.cs
@@ -38,6 +38,8 @@ namespace cse3902.Entities.Enemies
 
         private WallType wallType;
 
+        private (bool stun, float stunDuration) stun;
+
         public WallMaster(Game1 game, Vector2 start, Vector2 abstractStart)
         {
             this.game = game;
@@ -59,6 +61,8 @@ namespace cse3902.Entities.Enemies
             ConstructDetectionBox(abstractStart);
             this.collidable = new EnemyCollidable(this, this.Damage);
             health = SettingsValues.Instance.GetValue(SettingsValues.Variable.WallMasterHealth);
+
+            stun = (false, 0);
         }
 
         public void Attack()
@@ -118,8 +122,15 @@ namespace cse3902.Entities.Enemies
             }
         }
 
+        private void UpdateStun(GameTime gameTime)
+        {
+            stun.stunDuration -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+            stun.stun = stun.stunDuration > 0;
+        }
+
         public void Update(GameTime gameTime)
         {
+            UpdateStun(gameTime);
             UpdateDamage(gameTime);
 
             if (this.IsTriggered)
@@ -138,37 +149,39 @@ namespace cse3902.Entities.Enemies
 
         private void RegularMovement(GameTime gameTime)
         {
-            this.Center += direction * speed * (float)gameTime.ElapsedGameTime.TotalSeconds;
-
-            if (travelDistance <= 0)
+            if (!stun.stun)
             {
-                switch (this.wallType)
+                this.Center += direction * speed * (float)gameTime.ElapsedGameTime.TotalSeconds;
+
+                if (travelDistance <= 0)
                 {
-                    case WallType.LEFTWALL:
-                        LeftWallMovement();
-                        break;
+                    switch (this.wallType)
+                    {
+                        case WallType.LEFTWALL:
+                            LeftWallMovement();
+                            break;
 
-                    case WallType.RIGHTWALL:
-                        RightWallMovement();
-                        break;
+                        case WallType.RIGHTWALL:
+                            RightWallMovement();
+                            break;
 
-                    case WallType.BOTTOMWALL:
-                        BottomWallMovement();
-                        break;
+                        case WallType.BOTTOMWALL:
+                            BottomWallMovement();
+                            break;
 
-                    case WallType.TOPWALL:
-                        TopWallMovement();
-                        break;
+                        case WallType.TOPWALL:
+                            TopWallMovement();
+                            break;
 
-                    default:
-                        break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                {
+                    travelDistance--;
                 }
             }
-            else
-            {
-                travelDistance--;
-            }
-
 
             ChangeDirection(direction);
 
@@ -263,6 +276,12 @@ namespace cse3902.Entities.Enemies
         public ICollidable Collidable
         {
             get => this.collidable;
+        }
+
+        public (bool, float) Stunned
+        {
+            get => stun;
+            set => stun = value;
         }
 
         private void ConstructDetectionBox(Vector2 startingPosition)

--- a/cse3902/Entities/Enemies/Zol.cs
+++ b/cse3902/Entities/Enemies/Zol.cs
@@ -18,8 +18,7 @@ namespace cse3902.Entities.Enemies
 
         private Vector2 direction;
         private float speed;
-        private Vector2 center;
-        private Vector2 previousCenter;
+        private (Vector2 previous, Vector2 current) center;
         private int travelDistance;
         private Vector2 shoveDirection;
         private int shoveDistance;
@@ -28,14 +27,16 @@ namespace cse3902.Entities.Enemies
         private int health;
         private float remainingDamageDelay;
 
+        private (bool stun, float stunDuration) stun;
+
         public Zol(Game1 game, Vector2 start)
         {
             this.game = game;
-            center = start;
-            previousCenter = center;
+            center.current = start;
+            center.previous = start;
 
             //gel sprite sheet is 1 row, 2 columns
-            gelSprite = (ZolSprite)EnemySpriteFactory.Instance.CreateZolSprite(game.SpriteBatch, this.center);
+            gelSprite = (ZolSprite)EnemySpriteFactory.Instance.CreateZolSprite(game.SpriteBatch, this.center.current);
             speed = MovementConstants.ZolSpeed;
             travelDistance = 0;
             shoveDistance = MovementConstants.ZolShoveDistance;
@@ -43,6 +44,8 @@ namespace cse3902.Entities.Enemies
 
             this.collidable = new EnemyCollidable(this, this.Damage);
             health = SettingsValues.Instance.GetValue(SettingsValues.Variable.ZolHealth);
+
+            stun = (false, 0);
         }
 
         public ref Rectangle Bounds
@@ -83,8 +86,8 @@ namespace cse3902.Entities.Enemies
         public void Die()
         {
             SoundFactory.PlaySound(SoundFactory.Instance.enemyDie);
-            ItemSpriteFactory.Instance.SpawnRandomItem(game.SpriteBatch, center, IEntity.EnemyType.C);
-            if (ParticleEngine.Instance.UseParticleEffects) ParticleEngine.Instance.CreateEnemyDeathEffect(center);
+            ItemSpriteFactory.Instance.SpawnRandomItem(game.SpriteBatch, center.current, IEntity.EnemyType.C);
+            if (ParticleEngine.Instance.UseParticleEffects) ParticleEngine.Instance.CreateEnemyDeathEffect(center.current);
         }
 
         public void BeShoved()
@@ -113,8 +116,15 @@ namespace cse3902.Entities.Enemies
             }
         }
 
+        private void UpdateStun(GameTime gameTime)
+        {
+            stun.stunDuration -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+            stun.stun = stun.stunDuration > 0;
+        }
+
         public void Update(GameTime gameTime)
         {
+            UpdateStun(gameTime);
             UpdateDamage(gameTime);
             this.collidable.ResetCollisions();
             if (this.shoveDistance > 0) ShoveMovement();
@@ -129,41 +139,43 @@ namespace cse3902.Entities.Enemies
 
         private void RegularMovement(GameTime gameTime)
         {
-            this.Center += direction * speed * (float)gameTime.ElapsedGameTime.TotalSeconds;
-
-            if (travelDistance <= 0)
+            if (!stun.stun)
             {
-                Random rand = new System.Random();
-                int choice = rand.Next(0, 4);
-                travelDistance = MovementConstants.GelMaxTravel;
+                this.Center += direction * speed * (float)gameTime.ElapsedGameTime.TotalSeconds;
 
-                switch (choice)
+                if (travelDistance <= 0)
                 {
-                    case 0:
-                        direction.X = 1;
-                        direction.Y = 0;
-                        break;
-                    case 1:
-                        direction.X = -1;
-                        direction.Y = 0;
-                        break;
-                    case 2:
-                        direction.X = 0;
-                        direction.Y = 1;
-                        break;
-                    case 3:
-                        direction.X = 0;
-                        direction.Y = -1;
-                        break;
-                    default:
-                        break;
+                    Random rand = new System.Random();
+                    int choice = rand.Next(0, 4);
+                    travelDistance = MovementConstants.GelMaxTravel;
+
+                    switch (choice)
+                    {
+                        case 0:
+                            direction.X = 1;
+                            direction.Y = 0;
+                            break;
+                        case 1:
+                            direction.X = -1;
+                            direction.Y = 0;
+                            break;
+                        case 2:
+                            direction.X = 0;
+                            direction.Y = 1;
+                            break;
+                        case 3:
+                            direction.X = 0;
+                            direction.Y = -1;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                {
+                    travelDistance--;
                 }
             }
-            else
-            {
-                travelDistance--;
-            }
-
             gelSprite.Update(gameTime);
         }
 
@@ -174,7 +186,7 @@ namespace cse3902.Entities.Enemies
 
         public IEntity Duplicate()
         {
-            return new Zol(game, center);
+            return new Zol(game, center.current);
         }
 
         public IEntity.EnemyType Type
@@ -184,21 +196,21 @@ namespace cse3902.Entities.Enemies
 
         public Vector2 Center
         {
-            get => this.center;
+            get => this.center.current;
             set
             {
-                this.PreviousCenter = this.center;
-                this.center = value;
+                this.PreviousCenter = this.center.current;
+                this.center.current = value;
                 gelSprite.Center = value;
             }
         }
 
         public Vector2 PreviousCenter
         {
-            get => this.previousCenter;
+            get => this.center.previous;
             set
             {
-                this.previousCenter = value;
+                this.center.previous = value;
             }
         }
 
@@ -224,6 +236,12 @@ namespace cse3902.Entities.Enemies
         public ICollidable Collidable
         {
             get => this.collidable;
+        }
+
+        public (bool, float) Stunned
+        {
+            get => stun;
+            set => stun = value;
         }
     }
 }

--- a/cse3902/Entities/Link.cs
+++ b/cse3902/Entities/Link.cs
@@ -214,5 +214,11 @@ namespace cse3902.Entities
         {
             get => linkSprite.Size;
         }
+
+        public (bool, float) Stunned
+        {
+            get => (false, 0);
+            set { }
+        }
     }
 }

--- a/cse3902/Entities/LinkInventory.cs
+++ b/cse3902/Entities/LinkInventory.cs
@@ -73,7 +73,7 @@ namespace cse3902.Entities
                 linkState.Health = linkState.TotalHealth;
             } else if (type == InventoryManager.ItemType.Clock)
             {
-                if (game.RoomHandler.currentRoom != RoomUtilities.HORDE_ROOM) RoomEnemies.Instance.KillAll();
+                if (game.RoomHandler.currentRoom != RoomUtilities.HORDE_ROOM) RoomEnemies.Instance.ClockStun();
                 else linkState.Health += (linkState.TotalHealth - linkState.Health) / 2;
             }
             //pickup animation if certain item

--- a/cse3902/Game1.cs
+++ b/cse3902/Game1.cs
@@ -92,6 +92,7 @@ namespace cse3902
             GameStateManager.Instance.Game = this;
             VisionBlocker.Instance.Game = this;
             GameConditionManager.Instance.Game = this;
+            ProjectileHandler.Instance.Game = this;
 
             BlockSpriteFactory.Instance.LoadAllTextures(Content);
             DoorSpriteFactory.Instance.LoadAllTextures(Content);

--- a/cse3902/Interfaces/IEntity.cs
+++ b/cse3902/Interfaces/IEntity.cs
@@ -20,6 +20,7 @@ namespace cse3902.Interfaces
         public Vector2 Center { get; set; }
         public Vector2 PreviousCenter { get; }
         public EnemyType Type { get; }
+        public (bool Stun, float StunDuration) Stunned { get; set; }
 
         public void Attack();
         public void ChangeDirection(Vector2 direction);

--- a/cse3902/Projectiles/ArrowProjectile.cs
+++ b/cse3902/Projectiles/ArrowProjectile.cs
@@ -29,7 +29,7 @@ namespace cse3902.Projectiles
 
         private ICollidable collidable;
 
-        public ArrowProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Vector2 dir)
+        public ArrowProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Vector2 dir, Game1 game)
         {
             spriteBatch = batch;
             spriteTexture = texture;
@@ -67,7 +67,7 @@ namespace cse3902.Projectiles
             current.Y = (int)startingPos.Y;
 
             collisionTexture = ProjectileHandler.Instance.CreateStarAnimTexture();
-            this.collidable = new ProjectileCollidable(this);
+            this.collidable = new ProjectileCollidable(this, game);
 
             SoundFactory.PlaySound(SoundFactory.Instance.arrowBoomerang);
         }

--- a/cse3902/Projectiles/BombProjectile.cs
+++ b/cse3902/Projectiles/BombProjectile.cs
@@ -33,7 +33,7 @@ namespace cse3902.Projectiles
 
         private ICollidable collidable;
 
-        public BombProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos)
+        public BombProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Game1 game)
         {
             spriteBatch = batch;
             spriteTexture = texture;
@@ -54,7 +54,7 @@ namespace cse3902.Projectiles
             this.animationComplete = false;
             this.particlesGenerated = false;
 
-            this.collidable = new ProjectileCollidable(this);
+            this.collidable = new ProjectileCollidable(this, game);
 
             SoundFactory.PlaySound(SoundFactory.Instance.bombDrop);
         }

--- a/cse3902/Projectiles/BoomerangProjectile.cs
+++ b/cse3902/Projectiles/BoomerangProjectile.cs
@@ -29,15 +29,15 @@ namespace cse3902.Projectiles
         private bool collided;
 
         private ICollidable collidable;
-        private ISprite link;
+        private ISprite entity;
 
-        public BoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite link, Vector2 dir, Game1 game)
+        public BoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite entity, Vector2 dir, Game1 game, int travelDistance)
         {
             spriteBatch = batch;
             spriteTexture = texture;
 
-            this.link = link;
-            center = link.Center;
+            this.entity = entity;
+            center = entity.Center;
 
             frame.Width = spriteTexture.Width;
             frame.Height = spriteTexture.Height;
@@ -45,7 +45,7 @@ namespace cse3902.Projectiles
             direction.direction = dir;
             direction.alreadyReversed = false;
             angle = 0;
-            travelDistance = ItemConstants.BoomerangTravelDistance;
+            this.travelDistance = travelDistance;
 
             animationComplete = false;
 
@@ -65,8 +65,8 @@ namespace cse3902.Projectiles
             if (animationComplete) return -1;
 
             center += ItemConstants.BoomerangSpeed * direction.direction;
-            if (direction.direction.Y == 0) center.Y = link.Center.Y;
-            else center.X = link.Center.X;
+            if (direction.direction.Y == 0) center.Y = entity.Center.Y;
+            else center.X = entity.Center.X;
 
             travelDistance--;
             if (travelDistance == 0)
@@ -79,8 +79,8 @@ namespace cse3902.Projectiles
             if (angle >= 2 * ItemConstants.Angle180Rad) angle = 0;
             if (Math.Abs(angle - ItemConstants.AnglePiOver8) <= ItemConstants.epsilon) SoundFactory.PlaySound(SoundFactory.Instance.arrowBoomerang);
 
-            /* Animation is done if boomerang is travelling back to Link and collides with him */
-            if (travelDistance < 0 && link.Box.Intersects(this.Box))
+            /* Animation is done if boomerang is travelling back to the throwing entity and collides with it */
+            if (travelDistance < 0 && entity.Box.Intersects(this.Box))
             {
                 return -1;
             }

--- a/cse3902/Projectiles/BoomerangProjectile.cs
+++ b/cse3902/Projectiles/BoomerangProjectile.cs
@@ -22,7 +22,7 @@ namespace cse3902.Projectiles
 
         private Rectangle destination;
 
-        private Vector2 direction;
+        private (Vector2 direction, bool alreadyReversed) direction;
         private Vector2 center;
 
         private bool animationComplete;
@@ -31,7 +31,7 @@ namespace cse3902.Projectiles
         private ICollidable collidable;
         private ISprite link;
 
-        public BoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite link, Vector2 dir)
+        public BoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite link, Vector2 dir, Game1 game)
         {
             spriteBatch = batch;
             spriteTexture = texture;
@@ -42,13 +42,14 @@ namespace cse3902.Projectiles
             frame.Width = spriteTexture.Width;
             frame.Height = spriteTexture.Height;
 
-            direction = dir;
+            direction.direction = dir;
+            direction.alreadyReversed = false;
             angle = 0;
             travelDistance = ItemConstants.BoomerangTravelDistance;
 
             animationComplete = false;
 
-            this.collidable = new ProjectileCollidable(this);
+            this.collidable = new ProjectileCollidable(this, game);
         }
 
         public void Draw()
@@ -63,12 +64,16 @@ namespace cse3902.Projectiles
 
             if (animationComplete) return -1;
 
-            center += ItemConstants.BoomerangSpeed * direction;
-            if (direction.Y == 0) center.Y = link.Center.Y;
+            center += ItemConstants.BoomerangSpeed * direction.direction;
+            if (direction.direction.Y == 0) center.Y = link.Center.Y;
             else center.X = link.Center.X;
 
             travelDistance--;
-            if (travelDistance == 0) direction = -direction;
+            if (travelDistance == 0)
+            {
+                direction.alreadyReversed = true;
+                direction.direction = -direction.direction;
+            }
 
             angle += ItemConstants.AnglePiOver8;
             if (angle >= 2 * ItemConstants.Angle180Rad) angle = 0;
@@ -80,6 +85,16 @@ namespace cse3902.Projectiles
                 return -1;
             }
             return 0;
+        }
+
+        public void ReverseDirectionIfNecessary()
+        {
+            if (!direction.alreadyReversed)
+            {
+                direction.alreadyReversed = true;
+                direction.direction = -direction.direction;
+                travelDistance = -1;
+            }
         }
 
         public ref Rectangle Box
@@ -124,13 +139,13 @@ namespace cse3902.Projectiles
 
         public int Damage
         {
-            get => 0; //stuns if Link throws
+            get => DamageConstants.BoomerangDamage; //stuns if Link throws
         }
 
         public Vector2 Direction
         {
-            get => this.direction;
-            set => this.direction = value;
+            get => this.direction.direction;
+            set => this.direction.direction = value;
 
         }
 

--- a/cse3902/Projectiles/EnemyBoomerangProjectile.cs
+++ b/cse3902/Projectiles/EnemyBoomerangProjectile.cs
@@ -1,11 +1,8 @@
 ﻿using cse3902.Interfaces;
 using cse3902.Collision;
 using cse3902.Sprites;
-using cse3902.Sounds;
-using cse3902.Collision.Collidables;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 
 namespace cse3902.Projectiles
 {
@@ -13,9 +10,9 @@ namespace cse3902.Projectiles
     {
         private BoomerangProjectile boomerang;
 
-        public EnemyBoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite enemy, Vector2 dir)
+        public EnemyBoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite enemy, Vector2 dir, Game1 game)
         {
-            boomerang = new BoomerangProjectile(batch, texture, enemy, dir);
+            boomerang = new BoomerangProjectile(batch, texture, enemy, dir, game);
         }
 
         public void Draw()
@@ -27,6 +24,11 @@ namespace cse3902.Projectiles
         {
 
             return boomerang.Update(gameTime);
+        }
+
+        public void ReverseDirectionIfNecessary()
+        {
+            boomerang.ReverseDirectionIfNecessary();
         }
 
         public ref Rectangle Box

--- a/cse3902/Projectiles/EnemyBoomerangProjectile.cs
+++ b/cse3902/Projectiles/EnemyBoomerangProjectile.cs
@@ -1,6 +1,5 @@
 ﻿using cse3902.Interfaces;
 using cse3902.Collision;
-using cse3902.Sprites;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -10,9 +9,9 @@ namespace cse3902.Projectiles
     {
         private BoomerangProjectile boomerang;
 
-        public EnemyBoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite enemy, Vector2 dir, Game1 game)
+        public EnemyBoomerangProjectile(SpriteBatch batch, Texture2D texture, ISprite enemy, Vector2 dir, Game1 game, int travelDistance)
         {
-            boomerang = new BoomerangProjectile(batch, texture, enemy, dir, game);
+            boomerang = new BoomerangProjectile(batch, texture, enemy, dir, game, travelDistance);
         }
 
         public void Draw()

--- a/cse3902/Projectiles/Fireball.cs
+++ b/cse3902/Projectiles/Fireball.cs
@@ -28,7 +28,7 @@ namespace cse3902.Projectiles
         private ICollidable collidable;
         private IDependentParticleEmmiter fireballEmitter;
 
-        public Fireball(SpriteBatch spriteBatch, Texture2D texture, Vector2 startingPosition, Vector2 direction)
+        public Fireball(SpriteBatch spriteBatch, Texture2D texture, Vector2 startingPosition, Vector2 direction, Game1 game)
         {
             this.spriteBatch = spriteBatch;
             this.spriteTexture = texture;
@@ -40,7 +40,7 @@ namespace cse3902.Projectiles
 
             if (ParticleEngine.Instance.UseParticleEffects) fireballEmitter = ParticleEngine.Instance.CreateFireballEffect(this);
 
-            this.collidable = new ProjectileCollidable(this);
+            this.collidable = new ProjectileCollidable(this, game);
         }
 
         public Vector2 Center

--- a/cse3902/Projectiles/MagicBeamProjectile.cs
+++ b/cse3902/Projectiles/MagicBeamProjectile.cs
@@ -30,7 +30,7 @@ namespace cse3902.Projectiles
 
         private ICollidable collidable;
 
-        public MagicBeamProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Vector2 dir)
+        public MagicBeamProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Vector2 dir, Game1 game)
         {
             spriteBatch = batch;
             spriteTexture = texture;
@@ -46,7 +46,7 @@ namespace cse3902.Projectiles
 
             current = new Vector2(startingPos.X, startingPos.Y);
             collisionTexture = ProjectileHandler.Instance.CreatePoofAnim(spriteBatch, new Vector2(current.X, current.Y));
-            this.collidable = new ProjectileCollidable(this);
+            this.collidable = new ProjectileCollidable(this, game);
         }
 
         public void Draw()

--- a/cse3902/Projectiles/MagicFireballProjectile.cs
+++ b/cse3902/Projectiles/MagicFireballProjectile.cs
@@ -15,11 +15,11 @@ namespace cse3902.Projectiles
         ICollidable collidable;
         Rectangle box;
 
-        public MagicFireballProjectile(SpriteBatch spriteBatch, Texture2D texture, Vector2 startingPosition, Vector2 direction)
+        public MagicFireballProjectile(SpriteBatch spriteBatch, Texture2D texture, Vector2 startingPosition, Vector2 direction, Game1 game)
         {
-            fireball = new Fireball(spriteBatch, texture, startingPosition, direction);
+            fireball = new Fireball(spriteBatch, texture, startingPosition, direction, game);
             fireball.Speed = ItemConstants.MagicFireballSpeed;
-            collidable = new ProjectileCollidable(this);
+            collidable = new ProjectileCollidable(this, game);
         }
 
         public Vector2 Center

--- a/cse3902/Projectiles/ProjectileHandler.cs
+++ b/cse3902/Projectiles/ProjectileHandler.cs
@@ -20,6 +20,8 @@ namespace cse3902.Projectiles
         private Texture2D starAnim;
         private Texture2D poofAnim;
 
+        private Game1 game;
+
         private List<IProjectile> projectiles { get; set; }
 
         private static ProjectileHandler instance = new ProjectileHandler();
@@ -80,7 +82,7 @@ namespace cse3902.Projectiles
 
         public IProjectile CreateArrowItem(SpriteBatch spriteBatch, Vector2 startingPos, Vector2 dir)
         {
-            IProjectile newProj = new ArrowProjectile(spriteBatch, arrow, startingPos, dir);
+            IProjectile newProj = new ArrowProjectile(spriteBatch, arrow, startingPos, dir, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
@@ -88,7 +90,7 @@ namespace cse3902.Projectiles
 
         public IProjectile CreateBombItem(SpriteBatch spriteBatch, Vector2 startingPos)
         {
-            IProjectile newProj = new BombProjectile(spriteBatch, bomb, startingPos);
+            IProjectile newProj = new BombProjectile(spriteBatch, bomb, startingPos, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
@@ -96,14 +98,14 @@ namespace cse3902.Projectiles
 
         public IProjectile CreateBoomerangItem(SpriteBatch spriteBatch, LinkSprite linkState, Vector2 dir)
         {
-            IProjectile newProj = new BoomerangProjectile(spriteBatch, boomerang, linkState, dir);
+            IProjectile newProj = new BoomerangProjectile(spriteBatch, boomerang, linkState, dir, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
         }
         public IProjectile CreateFireballObject(SpriteBatch spriteBatch, Vector2 startingPos, Vector2 dir)
         {
-            IProjectile newProj = new Fireball(spriteBatch, fireball, startingPos, dir);
+            IProjectile newProj = new Fireball(spriteBatch, fireball, startingPos, dir, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
@@ -111,21 +113,21 @@ namespace cse3902.Projectiles
 
         public IProjectile CreateSwordItem(SpriteBatch spriteBatch, Vector2 startingPos, Vector2 dir)
         {
-            IProjectile newProj = new SwordProjectile(spriteBatch, swordItems, startingPos, dir);
+            IProjectile newProj = new SwordProjectile(spriteBatch, swordItems, startingPos, dir, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
         }
         public IProjectile CreateMagicFireball(SpriteBatch spriteBatch, Vector2 startingPos, Vector2 dir)
         {
-            IProjectile newProj = new MagicFireballProjectile(spriteBatch, fireball, startingPos, dir);
+            IProjectile newProj = new MagicFireballProjectile(spriteBatch, fireball, startingPos, dir, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
         }
         public IProjectile CreateMagicBeam(SpriteBatch spriteBatch, Vector2 startingPos, Vector2 dir)
         {
-            IProjectile newProj = new MagicBeamProjectile(spriteBatch, magicBeam, startingPos, dir);
+            IProjectile newProj = new MagicBeamProjectile(spriteBatch, magicBeam, startingPos, dir, game);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
@@ -147,6 +149,11 @@ namespace cse3902.Projectiles
         public ISprite CreatePoofAnim(SpriteBatch spriteBatch, Vector2 startingPos)
         {
             return new PoofSprite(spriteBatch, poofAnim, startingPos);
+        }
+
+        public Game1 Game
+        {
+            set => game = value;
         }
     }
 }

--- a/cse3902/Projectiles/ProjectileHandler.cs
+++ b/cse3902/Projectiles/ProjectileHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Content;
 using cse3902.Rooms;
+using cse3902.Constants;
 
 namespace cse3902.Projectiles
 {
@@ -98,11 +99,19 @@ namespace cse3902.Projectiles
 
         public IProjectile CreateBoomerangItem(SpriteBatch spriteBatch, LinkSprite linkState, Vector2 dir)
         {
-            IProjectile newProj = new BoomerangProjectile(spriteBatch, boomerang, linkState, dir, game);
+            IProjectile newProj = new BoomerangProjectile(spriteBatch, boomerang, linkState, dir, game, ItemConstants.BoomerangTravelDistance);
             projectiles.Add(newProj);
             RoomProjectiles.Instance.projectiles.Add(newProj);
             return newProj;
         }
+        public IProjectile CreateEnemyBoomerangItem(SpriteBatch spriteBatch, ISprite enemyState, Vector2 dir)
+        {
+            IProjectile newProj = new EnemyBoomerangProjectile(spriteBatch, boomerang, enemyState, dir, game, ItemConstants.EnemyBoomerangTravelDistance);
+            projectiles.Add(newProj);
+            RoomProjectiles.Instance.projectiles.Add(newProj);
+            return newProj;
+        }
+
         public IProjectile CreateFireballObject(SpriteBatch spriteBatch, Vector2 startingPos, Vector2 dir)
         {
             IProjectile newProj = new Fireball(spriteBatch, fireball, startingPos, dir, game);

--- a/cse3902/Projectiles/SwordProjectile.cs
+++ b/cse3902/Projectiles/SwordProjectile.cs
@@ -30,7 +30,7 @@ namespace cse3902.Projectiles
 
         private ICollidable collidable;
 
-        public SwordProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Vector2 dir)
+        public SwordProjectile(SpriteBatch batch, Texture2D texture, Vector2 startingPos, Vector2 dir, Game1 game)
         {
             spriteBatch = batch;
             spriteTexture = texture;
@@ -46,7 +46,7 @@ namespace cse3902.Projectiles
 
             current = new Vector2(startingPos.X, startingPos.Y);
             collisionTexture = ProjectileHandler.Instance.CreatePoofAnim(spriteBatch, new Vector2(current.X, current.Y));
-            this.collidable = new ProjectileCollidable(this);
+            this.collidable = new ProjectileCollidable(this, game);
         }
 
         public void Draw()

--- a/cse3902/Rooms/RoomData/RoomEnemies.cs
+++ b/cse3902/Rooms/RoomData/RoomEnemies.cs
@@ -3,15 +3,14 @@ using cse3902.Interfaces;
 using cse3902.Entities;
 using Microsoft.Xna.Framework;
 using System.Collections;
+using cse3902.Constants;
 
 namespace cse3902.Rooms
 {
     public class RoomEnemies
     {
         public IList enemies;
-
         private static RoomEnemies instance = new RoomEnemies();
-
         public static RoomEnemies Instance
         {
             get
@@ -19,7 +18,6 @@ namespace cse3902.Rooms
                 return instance;
             }
         }
-
         private RoomEnemies()
         {
             enemies = new List<IEntity>();
@@ -49,7 +47,6 @@ namespace cse3902.Rooms
                 }
             }
         }
-
         public void Draw()
         {
             if (CloudAnimation.Instance.cloudAnims.Count == 0)
@@ -66,12 +63,11 @@ namespace cse3902.Rooms
             oldList = new List<IEntity>();
 
             List<IEntity> enemytemp = enemies as List<IEntity>;
-
             for (int i = 0; i < enemies.Count; i++)
             {
+                enemytemp[i].Stunned = (false, 0);
                 oldList.Add(enemytemp[i]);
             }
-
             enemies.Clear();
 
             for (int i = 0; i < newList.Count; i++)
@@ -90,11 +86,14 @@ namespace cse3902.Rooms
             }
             enemies.Clear();
         }
-
-        public ref IList ListRef
+        public void ClockStun()
         {
-            get => ref enemies;
+            foreach (IEntity enemy in enemies)
+            {
+                enemy.Stunned = (true, DamageConstants.ClockStunDuration);
+            }
         }
 
+        public ref IList ListRef { get => ref enemies; }
     }
 }

--- a/cse3902/XMLParsing/Level1.xml
+++ b/cse3902/XMLParsing/Level1.xml
@@ -161,13 +161,13 @@
 			</item>
 			<item>
 				<type>Bomb</type>
-				<xloc>8</xloc>
+				<xloc>4</xloc>
 				<yloc>6</yloc>
 			</item>
 			<item>
 				<type>Fairy</type>
 				<xloc>8</xloc>
-				<yloc>5</yloc>
+				<yloc>6</yloc>
 			</item>
 			<item>
 				<type>BlueRing</type>
@@ -181,12 +181,7 @@
 			</item>
 			<item>
 				<type>Boomerang</type>
-				<xloc>8</xloc>
-				<yloc>5</yloc>
-			</item>
-			<item>
-				<type>Boomerang</type>
-				<xloc>8</xloc>
+				<xloc>7</xloc>
 				<yloc>6</yloc>
 			</item>
 			<item>


### PR DESCRIPTION
- Boomerangs and enemy boomerangs are both fully functional
- Clocks stun enemies instead of killing them

Details:
- Boomerang now stuns enemies for 2.5s
- Boomerang now immediately starts return after hitting a wall, enemy, or door
- Link is now immune to stunned enemies
- Clocks stun enemies until Link leaves the room
- Boomerang picks up any item it hits
- Enemy boomerangs now immediately starts return after hitting a wall, Link, or door
- Fixed bug where enemy projectiles would stop when hitting another enemy including itself
- Made boomerang speed and distance more game accurate
- Moved some items around in starting room to choose what you want easier (no double pickups)

Closes #344 
Closes #345